### PR TITLE
feat: add initial hacky support for impls with templated args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# VS Code
+**/*.vscode

--- a/substrait-expr/tests/integration_test.rs
+++ b/substrait-expr/tests/integration_test.rs
@@ -1,4 +1,5 @@
 use substrait_expr::builder::schema::SchemaBuildersExt;
+use substrait_expr::functions::functions_comparison::FunctionsComparisonExt;
 use substrait_expr::helpers::schema::{EmptySchema, SchemaInfo};
 use substrait_expr::helpers::types;
 use substrait_expr::{
@@ -56,6 +57,29 @@ pub fn test_building_simple_expression() {
                 .add(
                     builder.fields().resolve_by_name("location.x").unwrap(),
                     literal(3.0_f32),
+                )
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+
+    let expressions = builder.build();
+    dbg!(expressions);
+}
+
+#[test]
+pub fn test_expression_with_template_params() {
+    let schema = SchemaInfo::new_full().field("x", types::i32(false)).build();
+    let builder = ExpressionsBuilder::new(schema, BuilderParams::default());
+
+    builder
+        .add_expression(
+            "filter",
+            builder
+                .functions()
+                .lt(
+                    builder.fields().resolve_by_name("x").unwrap(),
+                    literal(0_i32),
                 )
                 .build()
                 .unwrap(),


### PR DESCRIPTION
This recognizes any type that is `T` or contains `any` as a templated arg which is a bit hacky.

On output type derivation, if the output is templated, then it just grabs the first input type, which is also hacky.

However, these rules work for most of the standard substrait yamls.